### PR TITLE
Fix Anchor Rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "4.3.2"
+  - "6.6.0"
+notifications:
+  email: false

--- a/index.js
+++ b/index.js
@@ -102,15 +102,24 @@ var javascriptToMarkdown = function(javascriptString) {
  The TOC plugin converts headings from raw strings to []() format, which can
  lead to differences in how marked renders the TOC and the main body.
 */
-var renderer = new marked.Renderer();
-var trailingDashRegExp = new RegExp('id=".*?[-]"');
-var trailingDashRemover = function(match, offset, string) {
-  return match.slice(0, -2) + match.slice(-1);
+var idRegExp = new RegExp('id=".*?"');
+var hrefRegExp = new RegExp('href="#(.*?)"');
+var idReplacer = function(newId) {
+  return function(match, offset, string) {
+    return 'id="' + newId + '"';
+  }
 };
 
+var renderer = new marked.Renderer();
 renderer.heading = function (text, level) {
   var renderedHeading = marked('#'.repeat(level) + ' ' + text);
-  return renderedHeading.replace(trailingDashRegExp, trailingDashRemover);
+
+  var tocRendering = marked(toc('# ' + text).content);
+  var matchInfo = tocRendering.match(hrefRegExp);
+  if (matchInfo) {
+    return renderedHeading.replace(idRegExp, idReplacer(matchInfo[1]));
+  }
+  return renderedHeading;
 };
 
 /*

--- a/index.js
+++ b/index.js
@@ -114,7 +114,8 @@ var renderer = new marked.Renderer();
 renderer.heading = function (text, level) {
   var renderedHeading = marked('#'.repeat(level) + ' ' + text);
 
-  var tocRendering = marked(toc('# ' + text).content);
+  var strippedText = cheerio.load(text).text();
+  var tocRendering = marked(toc('# ' + strippedText).content);
   var matchInfo = tocRendering.match(hrefRegExp);
   if (matchInfo) {
     return renderedHeading.replace(idRegExp, idReplacer(matchInfo[1]));

--- a/index.js
+++ b/index.js
@@ -176,10 +176,17 @@ var litdoc = function litdoc(options) {
   var templatePath = options.templatePath || path.join(__dirname, 'templates/index.jst');
   var template = options.template || fs.readFileSync(templatePath).toString();
 
+  var markdown;
   var markdownPath = options.markdownPath || undefined;
-  var markdown = options.markdown || fs.readFileSync(markdownPath).toString();
-  if (_.endsWith(markdownPath, '.js')) {
-    markdown = javascriptToMarkdown(markdown);
+  if (markdownPath) {
+    markdown = fs.readFileSync(markdownPath).toString();
+    if (_.endsWith(markdownPath, '.js')) {
+      markdown = javascriptToMarkdown(markdown);
+    }
+  } else if (options.markdown) {
+    markdown = options.markdown;
+  } else {
+    throw new Error('Must specify `markdown` or `markdownPath` option');
   }
 
   var outputPath = options.outputPath;

--- a/index.js
+++ b/index.js
@@ -97,6 +97,23 @@ var javascriptToMarkdown = function(javascriptString) {
 };
 
 /*
+ ## Custom Rendering
+
+ The TOC plugin converts headings from raw strings to []() format, which can
+ lead to differences in how marked renders the TOC and the main body.
+*/
+var renderer = new marked.Renderer();
+var trailingDashRegExp = new RegExp('id=".*?[-]"');
+var trailingDashRemover = function(match, offset, string) {
+  return match.slice(0, -2) + match.slice(-1);
+};
+
+renderer.heading = function (text, level) {
+  var renderedHeading = marked('#'.repeat(level) + ' ' + text);
+  return renderedHeading.replace(trailingDashRegExp, trailingDashRemover);
+};
+
+/*
 ## Markdown To HTML
 
 Renders Markdown into our "flavor" of row/bootstrap based HTML, which
@@ -109,7 +126,8 @@ var markdownToHTML = function(markdownString) {
         return code;
       }
       return hljs.highlight(lang, code).value;
-    }
+    },
+    renderer: renderer
   });
 
   var $ = cheerio.load('<div id="root">' + intermediaryOutput + '</div>');
@@ -158,8 +176,7 @@ var markdownToHTML = function(markdownString) {
   }
 
   return finalOutput;
-};
-
+}
 
 /*
 ## litdoc Export

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "docs": "node bin/docs.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node_modules/.bin/mocha -t 2000 --recursive test"
   },
   "repository": {
     "type": "git",
@@ -35,5 +35,9 @@
     "lodash": "^4.13.1",
     "markdown-toc": "^0.12.15",
     "marked": "^0.3.6"
+  },
+  "devDependencies": {
+    "mocha": "3.0.2",
+    "should": "11.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/zapier/litdoc#readme",
   "dependencies": {
     "acorn": "^2.7.0",
-    "cheerio": "^0.20.0",
+    "cheerio": "^0.22.0",
     "dedent": "^0.6.0",
     "dedent-js": "^1.0.1",
     "highlight.js": "^9.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -10,4 +10,10 @@ describe('litdoc', () => {
     html.should.containEql('<p>Hi there. <a href="http://example.com">Click Me</a>.</p>');
     html.should.containEql('<p>Second paragraph.</p>');
   });
+
+  it('should create valid anchors for headings that contain parentheses', () => {
+    var markdown = '# Contact Endpoint (deprecated)';
+    var html = litdoc({markdown: markdown})
+    html.should.containEql('<h1 id="contact-endpoint-deprecated">');
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -16,4 +16,10 @@ describe('litdoc', () => {
     var html = litdoc({markdown: markdown})
     html.should.containEql('<h1 id="contact-endpoint-deprecated">');
   });
+
+  it('should create valid anchors for headings that contain slashes', () => {
+    var markdown = '# Contact/Lead Endpoint';
+    var html = litdoc({markdown: markdown})
+    html.should.containEql('<h1 id="contactlead-endpoint">');
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -22,4 +22,14 @@ describe('litdoc', () => {
     var html = litdoc({markdown: markdown})
     html.should.containEql('<h1 id="contactlead-endpoint">');
   });
+
+  it('should create valid anchors for headings that contain stylization', () => {
+    var markdown = '# Your *index.js*';
+    var html = litdoc({markdown: markdown})
+    html.should.containEql('<h1 id="your-indexjs');
+
+    var markdown = '# Your `index.js`';
+    var html = litdoc({markdown: markdown})
+    html.should.containEql('<h1 id="your-indexjs');
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,13 @@
+var should = require('should');
+
+var litdoc = require('../index');
+
+describe('litdoc', () => {
+  it('should render markdown to html', () => {
+    var markdown = '# Big Heading\nHi there. [Click Me](http://example.com).\n\nSecond paragraph.';
+    var html = litdoc({markdown: markdown})
+    html.should.containEql('<h1 id="big-heading">Big Heading</h1>');
+    html.should.containEql('<p>Hi there. <a href="http://example.com">Click Me</a>.</p>');
+    html.should.containEql('<p>Second paragraph.</p>');
+  });
+});


### PR DESCRIPTION
Found two cases where headings were rendered with one slug in the TOC and a different slug in the HTML body. Those need to be consistent for the TOC to be helpful.